### PR TITLE
Remove promise.race for finally function which is better here

### DIFF
--- a/lib/command/start.js
+++ b/lib/command/start.js
@@ -16,25 +16,23 @@ async function getAvailablePort(reqPort) {
 }
 
 module.exports = cliOptions => {
-  const startCommand = fs.promises // check if justdocs folder exist.
+  fs.promises // check if justdocs folder exist.
     .access(path.resolve(`${CWD}/justdocs`))
     .then(() => {
-      fs.promises.readdir(`${CWD}/justdocs`, {withFileTypes: true})
-      .then(directory => {
-        
-      });
+      fs.promises
+        .readdir(`${CWD}/justdocs`, { withFileTypes: true })
+        .then(directory => {});
       // TODO: Check if 0.md file exist.
     })
     .catch(() => {
       console.log(chalk`{blue Start creating just-docs project..}`);
       fs.promises.mkdir(path.resolve(`${CWD}/justdocs`));
       // TODO: At this point we should generate an default justdocs app because this is the first time user launch the package.
+    })
+    .finally(function() {
+      console.log(chalk`{blue Starting the development server...}`);
+      // TODO: Create the webpack config here.
     });
-
-  Promise.race([startCommand]).then(async () => {
-    console.log(chalk`{blue Starting the development server...}`);
-    // TODO: Create the webpack config here.
-  });
 
   signals.forEach(signal => {
     process.on(signal, () => {


### PR DESCRIPTION
## Test Plan
This PR contains optimization code.

I deleted the `Promise.race()` function because she's useless in this case. Instead i'm using the `finally` function which is more helpful.

It also help me to delete the `startCommand` variable who release some space from the JS memory.
