### PR TITLE
Issue/2 - Check if `justdocs` folder is well configurated

### DIFF
--- a/lib/command/start.js
+++ b/lib/command/start.js
@@ -2,7 +2,6 @@ const chalk = require("chalk");
 const fs = require("fs");
 const path = require("path");
 const portfinder = require("portfinder");
-const webpack = require("webpack");
 const { DEFAULT_PORT, CONFIG_FILE_NAME } = require("../config");
 
 const CWD = process.cwd();
@@ -66,6 +65,7 @@ function parseDirectory(directory) {
 }
 
 module.exports = cliOptions => {
+  console.log(cliOptions);
   fs.promises // check if justdocs folder exist.
     .access(path.resolve(`${CWD}/justdocs`))
     .catch(() => {
@@ -77,6 +77,7 @@ module.exports = cliOptions => {
     .then(directory => parseDirectory(directory))
     .finally(() => {
       console.log(chalk`{blue Starting the development server...}`);
+      getAvailablePort();
       // TODO: Create the webpack config here.
     });
 

--- a/lib/command/start.js
+++ b/lib/command/start.js
@@ -16,7 +16,7 @@ async function getAvailablePort(reqPort) {
 
 /**
  * Parse the `justdocs` folder to check if everything is correct.
- * @param {Array} directory An array of files return by the `readir` function.
+ * @param {Array} directory An array of files return by the `fs.promises.readdir` function.
  */
 function parseDirectory(directory) {
   let hasjustdocs = false;

--- a/lib/command/start.js
+++ b/lib/command/start.js
@@ -3,10 +3,9 @@ const fs = require("fs");
 const path = require("path");
 const portfinder = require("portfinder");
 const webpack = require("webpack");
-const { DEFAULT_PORT } = require("../config");
+const { DEFAULT_PORT, CONFIG_FILE_NAME } = require("../config");
 
 const CWD = process.cwd();
-const signals = ["SIGINT", "SIGTERM"];
 
 async function getAvailablePort(reqPort) {
   const baseport = reqPort ? parseInt(reqPort, 10) : DEFAULT_PORT;
@@ -15,28 +14,74 @@ async function getAvailablePort(reqPort) {
   return port;
 }
 
+/**
+ * Parse the `justdocs` folder to check if everything is correct.
+ * @param {Array} directory An array of files return by the `readir` function.
+ */
+function parseDirectory(directory) {
+  let hasjustdocs = false;
+
+  directory.forEach(file => {
+    const fileExtension = path.extname(file.name);
+
+    if (file.isDirectory()) {
+      // justdocs doesn't contains folder, check if true.
+      console.error(
+        chalk`{red justdocs folder should only contain files, you've created ${chalk.bgRed.black(
+          file.name
+        )} folder}`
+      );
+      process.exit();
+    }
+
+    if (path.extname(file.name) === ".json") {
+      // just docs can only have one justdocs.json
+      if (hasjustdocs) {
+        console.error(chalk`{red You can only have one json file}`);
+        process.exit();
+      }
+
+      if (path.basename(file.name) !== CONFIG_FILE_NAME) {
+        console.error(
+          chalk`{red justdocs folder should have a ${chalk.bgRed.black(
+            CONFIG_FILE_NAME
+          )} file.}`
+        );
+        process.exit();
+      }
+
+      hasjustdocs = true;
+    }
+
+    if (![".md", ".json"].includes(fileExtension)) {
+      // justdocs only contains .md and .json files.
+      console.error(
+        chalk`{red justdocs folder should only contain files with the .md extension, you've created ${chalk.bgRed.black(
+          file.name
+        )}}`
+      );
+      process.exit();
+    }
+  });
+}
+
 module.exports = cliOptions => {
   const startCommand = fs.promises // check if justdocs folder exist.
     .access(path.resolve(`${CWD}/justdocs`))
-    .then(() => {
-      fs.promises.readdir(`${CWD}/justdocs`, {withFileTypes: true})
-      .then(directory => {
-        
-      });
-      // TODO: Check if 0.md file exist.
-    })
     .catch(() => {
       console.log(chalk`{blue Start creating just-docs project..}`);
       fs.promises.mkdir(path.resolve(`${CWD}/justdocs`));
       // TODO: At this point we should generate an default justdocs app because this is the first time user launch the package.
-    });
+    })
+    .then(() => fs.promises.readdir(`${CWD}/justdocs`, { withFileTypes: true }))
+    .then(directory => parseDirectory(directory));
 
   Promise.race([startCommand]).then(async () => {
     console.log(chalk`{blue Starting the development server...}`);
     // TODO: Create the webpack config here.
   });
 
-  signals.forEach(signal => {
+  ["SIGINT", "SIGTERM"].forEach(signal => {
     process.on(signal, () => {
       console.log(chalk`\n{yellow Just-docs is closed see you 👋👋}`);
       process.exit();


### PR DESCRIPTION
## Test Plan
*The goal of this PR is to check if justdocs folder is well configurated when user start the `start` command in his terminal.*

> **Note** - justdocs folder must be at the root of your folder and contains all `.md` files and can have only one `.json` file, which is `justdocs.json`.

To check that I created the `parseDirectory` function which is called l.77 when `fs.promises.access` promise return resolved, it means the user already have an justdocs folder in his directory. We now need to check if he fulfills several conditions:

* justdocs folder shouldn't contains folder only files.
* justdocs folder should only contains files with those extensions `.md, .json`.
* justdocs folder can have several `.md` files but only one `.json`.
* justdocs folder should have only one `.json` file called `justdocs.json`.